### PR TITLE
Rename tokenCreated to permanentTokenCreated

### DIFF
--- a/graphql/resolvers/Mutation.js
+++ b/graphql/resolvers/Mutation.js
@@ -273,8 +273,8 @@ const MutationResolver = (
             customName: databaseToken.customName,
             user: { id: context.auth.userId },
           }
-          pubsub.publish('tokenCreated', {
-            tokenCreated: resolveObj,
+          pubsub.publish('permanentTokenCreated', {
+            permanentTokenCreated: resolveObj,
             userId: context.auth.userId,
           })
 

--- a/graphql/resolvers/subscriptions.js
+++ b/graphql/resolvers/subscriptions.js
@@ -27,7 +27,7 @@ const subscriptionResolver = (pubsub, { User, Device, Board }) => ({
   boardCreated: subscriptionFilterOnlyMine('boardCreated', pubsub),
   deviceCreated: subscriptionFilterOwnedOrShared('deviceCreated', pubsub),
   valueCreated: subscriptionFilterOwnedOrShared('valueCreated', pubsub),
-  tokenCreated: subscriptionFilterOnlyMine('tokenCreated', pubsub),
+  permanentTokenCreated: subscriptionFilterOnlyMine('permanentTokenCreated', pubsub),
   plotNodeCreated: subscriptionFilterOwnedOrShared('plotNodeCreated', pubsub),
   stringPlotNodeCreated: subscriptionFilterOwnedOrShared(
     'stringPlotNodeCreated',

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -607,7 +607,7 @@ type Subscription {
   # subscribes to string plot node creations
   stringPlotNodeCreated: StringPlotNode
   #subscribes to token creations
-  tokenCreated: PermanentToken
+  permanentTokenCreated: PermanentToken
   # subscribes to notification creations
   notificationCreated: Notification
   # subscribes to board shares


### PR DESCRIPTION
Replaced references to `tokenCreated` with `permanentTokenCreated` in the repo.