### PR TITLE
Update Mutation.js

### DIFF
--- a/graphql/resolvers/Mutation.js
+++ b/graphql/resolvers/Mutation.js
@@ -996,6 +996,10 @@ const MutationResolver = (
   user(root, args, context) {
     let permissionRequired
     const mutationFields = Object.keys(args)
+    if(args.displayName===null || args.displayName===""){
+         reject('displayName cannot be null or empty')
+         return
+    }
     if (mutationFields.length === 1 && mutationFields[0] === 'usageCap') {
       permissionRequired = ['TEMPORARY', 'PERMANENT', 'CHANGE_USAGE_CAP']
     } else if (


### PR DESCRIPTION
#53
A user shouldn't be allowed to change its name to "" 
Add a check that args.displayName isn't empty in the user mutation handler